### PR TITLE
计时方式改进：使用系统时间代替tick数量

### DIFF
--- a/src/main/java/cn/ctcraft/ctonlinereward/CtOnlineReward.java
+++ b/src/main/java/cn/ctcraft/ctonlinereward/CtOnlineReward.java
@@ -4,6 +4,7 @@ import cn.ctcraft.ctonlinereward.command.CommandHandler;
 import cn.ctcraft.ctonlinereward.database.*;
 import cn.ctcraft.ctonlinereward.inventory.RewardSetInventoryMonitor;
 import cn.ctcraft.ctonlinereward.listner.InventoryMonitor;
+import cn.ctcraft.ctonlinereward.listner.PlayerMonitor;
 import cn.ctcraft.ctonlinereward.service.OnlineTimer;
 import cn.ctcraft.ctonlinereward.service.RemindTimer;
 import cn.ctcraft.ctonlinereward.service.YamlService;
@@ -42,6 +43,7 @@ public final class CtOnlineReward extends JavaPlugin {
         this.getCommand("cor").setExecutor(CommandHandler.getInstance());
         getServer().getPluginManager().registerEvents(RewardSetInventoryMonitor.getInstance(), this);
         getServer().getPluginManager().registerEvents(new InventoryMonitor(), this);
+        getServer().getPluginManager().registerEvents(new PlayerMonitor(), this);
 
         load();
 

--- a/src/main/java/cn/ctcraft/ctonlinereward/listner/PlayerMonitor.java
+++ b/src/main/java/cn/ctcraft/ctonlinereward/listner/PlayerMonitor.java
@@ -1,13 +1,19 @@
 package cn.ctcraft.ctonlinereward.listner;
 
-import cn.ctcraft.ctonlinereward.CtOnlineReward;
+import cn.ctcraft.ctonlinereward.service.OnlineTimer;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 
 public class PlayerMonitor implements Listener {
     @EventHandler
-    public void joinMonitor(PlayerJoinEvent event){
+    public void joinMonitor(PlayerJoinEvent event) {
+        OnlineTimer.addOnlinePlayer(event.getPlayer(), System.currentTimeMillis());
+    }
 
+    @EventHandler
+    public void quitMonitor(PlayerQuitEvent event) {
+        OnlineTimer.removeOnlinePlayer(event.getPlayer());
     }
 }

--- a/src/main/java/cn/ctcraft/ctonlinereward/service/OnlineTimer.java
+++ b/src/main/java/cn/ctcraft/ctonlinereward/service/OnlineTimer.java
@@ -2,49 +2,68 @@ package cn.ctcraft.ctonlinereward.service;
 
 import cn.ctcraft.ctonlinereward.CtOnlineReward;
 import cn.ctcraft.ctonlinereward.database.DataService;
-import cn.ctcraft.ctonlinereward.database.YamlData;
 import cn.ctcraft.ctonlinereward.pojo.OnlineRemind;
 import cn.ctcraft.ctonlinereward.service.afk.AfkService;
 import cn.ctcraft.ctonlinereward.utils.ConfigUtil;
 import org.bukkit.Bukkit;
-import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
-import org.bukkit.scheduler.BukkitTask;
 
-import java.text.SimpleDateFormat;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.UUID;
 
 public class OnlineTimer extends BukkitRunnable {
     private static OnlineTimer instance = new OnlineTimer();
+    private static HashMap<UUID, Long> onlinePlayerTime = new HashMap<>();
     private DataService dataService = CtOnlineReward.dataService;
     private CtOnlineReward ctOnlineReward = CtOnlineReward.getPlugin(CtOnlineReward.class);
-    private OnlineTimer(){
+
+    private OnlineTimer() {
     }
+
     public static OnlineTimer getInstance() {
         return instance;
     }
 
+    public static void addOnlinePlayer(Player player, Long time) {
+        onlinePlayerTime.put(player.getUniqueId(), time);
+    }
+
+    public static void removeOnlinePlayer(Player player) {
+        onlinePlayerTime.remove(player.getUniqueId());
+    }
 
     @Override
     public void run() {
         Collection<? extends Player> onlinePlayers = Bukkit.getServer().getOnlinePlayers();
         for (Player player : onlinePlayers) {
-            boolean afk = AfkService.getInstance().isAfk(player);
-            if (afk){
+            if (!onlinePlayerTime.containsKey(player.getUniqueId())) {
                 return;
             }
-            int playerOnlineTime = dataService.getPlayerOnlineTime(player);
-            int i = playerOnlineTime + 1;
-            dataService.addPlayerOnlineTime(player,i);
+            if (AfkService.getInstance().isAfk(player)) {
+                return;
+            }
+
+            int numMinutes = dataService.getPlayerOnlineTime(player);
+            long playerOnlineTime = onlinePlayerTime.get(player.getUniqueId());
+            long timePast = System.currentTimeMillis() - playerOnlineTime;
+            if (timePast > 60 * 1000) {
+                numMinutes += ((Long) (timePast / (60 * 1000))).intValue();
+                dataService.addPlayerOnlineTime(player, numMinutes);
+
+                long newTime = System.currentTimeMillis() - (timePast % 60000);
+                onlinePlayerTime.put(player.getUniqueId(), newTime);
+            }
+
             boolean onlineRemind = ctOnlineReward.getConfig().getBoolean("Setting.onlineRemind.use");
-            if (onlineRemind){
+            if (onlineRemind) {
                 try {
                     List<OnlineRemind> objectList = ConfigUtil.getObjectList(ctOnlineReward.getConfig(), "Setting.onlineRemind.remindValues", OnlineRemind.class);
                     for (OnlineRemind remind : objectList) {
-                        if (i == remind.getOnlineTime()){
-                            player.sendMessage(remind.getMessage().replace("&","§"));
+                        if (numMinutes == remind.getOnlineTime()) {
+                            player.sendMessage(remind.getMessage().replace("&", "§"));
                         }
                     }
                 } catch (Exception e) {


### PR DESCRIPTION
使用系统时间计算玩家在线时间，而非基于tick数进行计算
在服务器处于较高延迟状态时，系统时间不会影响实际计时

已通过本人服务器实际使用测试